### PR TITLE
Dev/util type-of

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 # Change Log
 
 ## [Unreleased]
+### Removed
+- `TypeOf` type
 
 ## [0.5.0] - 2022-03-04
 ### Added

--- a/src/util/__tests__/type-of.test.ts
+++ b/src/util/__tests__/type-of.test.ts
@@ -1,17 +1,17 @@
 import { toStringTag, typeOf } from "../type-of";
 
 const primitives = [
-    ["string", "String"],
-    [0, "Number"],
+    ["string",  "String"],
+    [0,         "Number"],
     [BigInt(0), "BigInt"],
-    [true, "Boolean"],
-    [Symbol(), "Symbol"],
-    [null, "Null"],
-    [void 0, "Undefined"],
+    [true,      "Boolean"],
+    [Symbol(),  "Symbol"],
+    [null,      "Null"],
+    [void 0,    "Undefined"],
 ] as const;
 
 describe("toStringTag", () => {
-    test.each(primitives)("toStringTag(%p) === \"%s\"", (value, stringTag) => {
+    test.each(primitives)("toStringTag(%p)", (value, stringTag) => {
         expect(toStringTag(value)).toBe(stringTag);
     });
     test("object", () => {
@@ -19,12 +19,12 @@ describe("toStringTag", () => {
         expect(toStringTag(/./)).toBe("RegExp");
         expect(toStringTag({ [Symbol.toStringTag]: "StringTag" })).toBe("StringTag");
         expect(toStringTag({})).toBe("Object");
-        expect(toStringTag(new class Class {})).toBe("Object");
+        expect(toStringTag(new class MyClass {})).toBe("Object");
     });
 });
 
 describe("typeOf", () => {
-    test.each(primitives)("typeOf(%p) === \"%s\"", (value, stringTag) => {
+    test.each(primitives)("typeOf(%p)", (value, stringTag) => {
         expect(typeOf(value)).toBe(stringTag.toLowerCase());
     });
     test("object", () => {
@@ -32,7 +32,10 @@ describe("typeOf", () => {
         expect(typeOf(/./)).toBe("RegExp");
         expect(typeOf({ [Symbol.toStringTag]: "StringTag" })).toBe("StringTag");
         expect(typeOf({})).toBe("Object");
-        expect(typeOf(new class Class {})).toBe("Class");
+        expect(typeOf(new class MyClass {})).toBe("MyClass");
+    });
+    test("invalid constructor", () => {
+        expect(typeOf({ constructor: null })).toBe("Object");
         expect(typeOf({ constructor: { name: "" } })).toBe("Object");
         expect(typeOf({ constructor: { name: 42 } })).toBe("Object");
     });

--- a/src/util/type-of.ts
+++ b/src/util/type-of.ts
@@ -32,10 +32,6 @@ type ObjectToStringTag<T extends object> = (
 // eslint-disable-next-line @typescript-eslint/unbound-method
 const objectPrototypeToString: (this: unknown) => string = Object.prototype.toString;
 
-// プリミティブ型はキャッシュしないため空の状態でマッチすることはない。
-let prevInput: unknown;
-let prevResult: string;
-
 export type ToStringTag<T> = object extends T ? StringTag // any | unknown
     : T extends object ? ObjectToStringTag<T>
     : PrimitiveToStringTag<T>;
@@ -56,11 +52,8 @@ export const toStringTag = <T>(value: T): ToStringTag<T> => {
         ] as ToStringTag<T>;
     }
 
-    if(prevInput === value) return prevResult as ToStringTag<T>;
-
-    prevInput = value;
-    prevResult = objectPrototypeToString.call(value).slice(8, -1);
-    return prevResult as ToStringTag<T>;
+    return objectPrototypeToString.call(value)
+        .slice(8, -1) as ToStringTag<T>;
 };
 
 export type TypeOf<T> = object extends T ? StringTag // any | unknown
@@ -87,12 +80,13 @@ export const typeOf = <T>(value: T): TypeOf<T> => {
         return typeof value as TypeOf<T>;
     }
 
-    if(toStringTag(value) === "Object") {
+    const stringTag = toStringTag(value);
+    if(stringTag === "Object") {
         const ctorName: unknown = (value as unknown as object).constructor?.name;
         if(typeof ctorName === "string" && ctorName) {
             return ctorName as TypeOf<T>;
         }
     }
 
-    return prevResult as TypeOf<T>;
+    return stringTag as StringTag as TypeOf<T>;
 };

--- a/src/util/type-of.ts
+++ b/src/util/type-of.ts
@@ -56,10 +56,6 @@ export const toStringTag = <T>(value: T): ToStringTag<T> => {
         .slice(8, -1) as ToStringTag<T>;
 };
 
-export type TypeOf<T> = object extends T ? StringTag // any | unknown
-    : T extends object ? ObjectToStringTag<T>
-    : Lowercase<PrimitiveToStringTag<T>>;
-
 /**
  * if null, returns "null".
  * if primitive, use typeof operator to get the type.
@@ -71,22 +67,22 @@ export type TypeOf<T> = object extends T ? StringTag // any | unknown
  * @param value Value to get the type
  * @returns String of type of {@link value}
  */
-export const typeOf = <T>(value: T): TypeOf<T> => {
+export const typeOf = (value: unknown): string => {
     if(value === null) {
-        return "null" as TypeOf<T>;
+        return "null";
     }
 
     if(isPrimitive(value)) {
-        return typeof value as TypeOf<T>;
+        return typeof value;
     }
 
     const stringTag = toStringTag(value);
     if(stringTag === "Object") {
         const ctorName: unknown = (value as unknown as object).constructor?.name;
         if(typeof ctorName === "string" && ctorName) {
-            return ctorName as TypeOf<T>;
+            return ctorName;
         }
     }
 
-    return stringTag as StringTag as TypeOf<T>;
+    return stringTag;
 };

--- a/src/util/type-of.ts
+++ b/src/util/type-of.ts
@@ -38,10 +38,6 @@ export type ToStringTag<T> = object extends T ? StringTag // any | unknown
 
 /**
  * Use `Object.prototype.toString` to get the value type.
- *
- * @see {@link typeOf}
- * @param value Value to get the type
- * @returns String of type of {@link value}
  */
 export const toStringTag = <T>(value: T): ToStringTag<T> => {
     const inputType = typeof value;
@@ -57,15 +53,13 @@ export const toStringTag = <T>(value: T): ToStringTag<T> => {
 };
 
 /**
- * if null, returns "null".
- * if primitive, use typeof operator to get the type.
- * if {@link toStringTag}(value) same "Object" and `value.constructor.name` isn't empty,
- * return `value.constructor.name`.
- * else, same as {@link toStringTag}.
+ * if null, return "null".
+ * if primitive, use the `typeof` operator to get the type.
+ * if {@link toStringTag}(value) is "Object" and `value.constructor.name` isn't empty,
+ * return it.
+ * otherwise, same as {@link toStringTag}.
  *
  * @see {@link toStringTag}
- * @param value Value to get the type
- * @returns String of type of {@link value}
  */
 export const typeOf = (value: unknown): string => {
     if(value === null) {


### PR DESCRIPTION
`util/type-of.ts`の複雑さの解消。

`toStringTag`のキャッシュを消す。

- キャッシュすると動的にタグが変わると対応できない。
流石に無いだろうが例としてはこういうの
```js
const RandomStringTag = {
    get [Symbol.toStringTag]() {
        return Math.random() > 0.5 ? "Hoge" : "Fuga";
    }
};
```

- メモリリーク
前回の値を保持し続けるので弱参照でないとGCに拾ってもらえないが、`Object.prototype.toString`はそこまでしてキャッシュするほど重い処理ではない。
